### PR TITLE
Add support for acceptFirstMouse on window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 lib/
 .tmp/
 *.log
+/.idea

--- a/examples/accept-first-mouse.js
+++ b/examples/accept-first-mouse.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import Ionize from 'react-ionize';
+import path from 'path';
+
+import 'index.html';
+
+Ionize.start(
+  <window show
+          acceptFirstMouse
+          file={path.resolve(__dirname, "index.html")}
+          position={[200, 200]}
+  />
+);

--- a/examples/index.html
+++ b/examples/index.html
@@ -6,5 +6,6 @@
   </head>
   <body>
     <h1>Hello, Electron!</h1>
+    <button>Hi!</button>
   </body>
 </html>

--- a/src/elements/WindowElement.js
+++ b/src/elements/WindowElement.js
@@ -98,6 +98,7 @@ const SUPPORTED_PROPS = {
   'onReadyToShow': true,
   'onResize': true,
   'showDevTools': true,
+  'defaultAcceptFirstMouse': true,
 };
 
 const PROP_TO_APP_EVENT_NAME = {
@@ -118,7 +119,10 @@ export default class WindowElement extends BaseElement {
   ) {
     super(props, rootContainer);
 
-    this.window = new BrowserWindow({ show: false });
+    this.window = new BrowserWindow({
+      show: false,
+      acceptFirstMouse: !!props.defaultAcceptFirstMouse
+    });
     this.parentWindow = null;
     this.attachedHandlers = {};
   }

--- a/src/elements/WindowElement.js
+++ b/src/elements/WindowElement.js
@@ -98,7 +98,7 @@ const SUPPORTED_PROPS = {
   'onReadyToShow': true,
   'onResize': true,
   'showDevTools': true,
-  'defaultAcceptFirstMouse': true,
+  'acceptFirstMouse': true,
 };
 
 const PROP_TO_APP_EVENT_NAME = {
@@ -121,7 +121,7 @@ export default class WindowElement extends BaseElement {
 
     this.window = new BrowserWindow({
       show: false,
-      acceptFirstMouse: !!props.defaultAcceptFirstMouse
+      acceptFirstMouse: !!props.acceptFirstMouse
     });
     this.parentWindow = null;
     this.attachedHandlers = {};
@@ -244,6 +244,9 @@ export default class WindowElement extends BaseElement {
           configureFile.call(this, newProps);
           break;
         }
+        case 'acceptFirstMouse':
+          console.warn('Warning: you cannot change acceptFirstMouse after the first render');
+          break;
       }
     }
   }

--- a/src/elements/WindowElement.js
+++ b/src/elements/WindowElement.js
@@ -9,6 +9,7 @@ import type { ElectronApp } from 'electron';
 import type IonizeContainer from '../IonizeContainer';
 import type { HostContext } from '../IonizeHostConfig';
 import configureWrappedEventHandler from '../util/configureWrappedEventHandler';
+import { getCurrentFiberStackAddendum } from 'react-dom/lib/ReactDebugCurrentFiber';
 
 /* PROPS NEEDED
  * title
@@ -245,7 +246,14 @@ export default class WindowElement extends BaseElement {
           break;
         }
         case 'acceptFirstMouse':
-          console.warn('Warning: you cannot change acceptFirstMouse after the first render');
+          if (process.env.NODE_ENV !== 'production') {
+            console.warn(
+              'A component is changing the acceptFirstMouse prop of a window. ' +
+              'The acceptFirstMouse prop only has effect when the window is first rendered, ' +
+              'changing it after the first render does nothing. ' +
+              getCurrentFiberStackAddendum()
+            );
+          }
           break;
       }
     }


### PR DESCRIPTION
Hey man!

Stumbled upon this project yesterday and I think this is a great idea!  Figured I couldn't come empty handed, so here's my first attempt at a contribution. I immediately ran into some interesting stuff because `acceptFirstMouse` can only be passed as an option in the constructor of `Window`, which made me think that it only supports being 'uncontrolled'... I think...

Had some trouble testing this as well, so that's still missing. I didn't want to spend a lot of time on that before checking whether this prop is a good idea in the first place. Maybe you were planning on passing the initial options in a different way?

Anyway, love the idea, I'm definitely going to dive into how you got this to work.