### PR TITLE
Add badge prop on app element, mapped to setBadge

### DIFF
--- a/examples/main.js
+++ b/examples/main.js
@@ -11,11 +11,12 @@ class ExampleApp extends React.Component {
       show: false,
       size: [300, 300],
       position: [100, 100],
+      badge: "123"
     };
   }
 
   render() {
-    return <app>
+    return <app badge={this.state.badge}>
       <menu>
         <submenu label="Electron">
           <about />

--- a/examples/main.js
+++ b/examples/main.js
@@ -11,12 +11,27 @@ class ExampleApp extends React.Component {
       show: false,
       size: [300, 300],
       position: [100, 100],
-      badge: "123"
+      bounce: false,
     };
   }
 
+  componentDidMount() {
+    setTimeout(() => {
+      this.setState({
+        bounce: true,
+      });
+    }, 3000);
+
+    setTimeout(() => {
+      this.setState({
+        bounce: false,
+      });
+    }, 6000);
+  }
+
   render() {
-    return <app badge={this.state.badge}>
+    return <app>
+      <dock badge="Hey" bouncing={this.state.bounce ? 'critical' : false} />
       <menu>
         <submenu label="Electron">
           <about />

--- a/interfaces/electron.js
+++ b/interfaces/electron.js
@@ -2,7 +2,11 @@ declare module 'electron' {
   declare var dialog: any;
 
   declare type ElectronDock = {
-    setBadge: (string) => void
+    setBadge: (string) => void,
+    hide: () => void,
+    show: () => void,
+    cancelBounce: (id: number) => void,
+    bounce: (type?: string) => number,
   }
 
   declare type ElectronApp = {|

--- a/interfaces/electron.js
+++ b/interfaces/electron.js
@@ -1,6 +1,10 @@
 declare module 'electron' {
   declare var dialog: any;
 
+  declare type ElectronDock = {
+    setBadge: (string) => void
+  }
+
   declare type ElectronApp = {|
     isReady: () => boolean,
     on: (string, Function) => ElectronApp,
@@ -8,6 +12,8 @@ declare module 'electron' {
     removeListener: (string, Function) => ElectronApp,
 
     test_makeReady: () => void,
+
+    dock: ElectronDock,
   |};
 
   declare var app: ElectronApp;

--- a/src/elements/AppElement.js
+++ b/src/elements/AppElement.js
@@ -11,6 +11,10 @@ const PROP_TO_APP_EVENT_NAME = {
   'onReady'               : 'ready',
 };
 
+const SUPPORTED_PROPS = {
+  badge: true,
+};
+
 export default class AppElement extends BaseElement {
   rootContainer : IonizeContainer;
   attachedHandlers: {[string]: Function};
@@ -23,6 +27,8 @@ export default class AppElement extends BaseElement {
 
     this.rootContainer = rootContainer;
     this.attachedHandlers = {};
+
+    if (props.badge) this.rootContainer.app.dock.setBadge(props.badge);
   }
 
   getPublicInstance(
@@ -30,6 +36,10 @@ export default class AppElement extends BaseElement {
     // TODO: We should probably return a proxy object so the user can't go
     // crazy with the possibilities here.
     return this.rootContainer.app;
+  }
+
+  getSupportedProps(): { [string]: boolean } {
+    return SUPPORTED_PROPS;
   }
 
   // Hook up event handlers, if they exist
@@ -73,6 +83,24 @@ export default class AppElement extends BaseElement {
     for (const eventKey in this.attachedHandlers) {
       const handler = this.attachedHandlers[eventKey];
       this.rootContainer.app.removeListener(eventKey, handler);
+    }
+  }
+
+  commitUpdate(
+    updatePayload : Array<mixed>,
+    oldProps      : Object,
+    newProps      : Object
+  ): void {
+    for (let i = 0; i < updatePayload.length; i += 2) {
+      let propKey = ((updatePayload[i]: any): string);
+      let propVal = updatePayload[i+1];
+      switch (propKey) {
+        case 'badge': {
+          propVal = ((propVal: any): string);
+          this.rootContainer.app.dock.setBadge(propVal);
+          break;
+        }
+      }
     }
   }
 }

--- a/src/elements/AppElement.js
+++ b/src/elements/AppElement.js
@@ -4,6 +4,7 @@ import BaseElement from './BaseElement';
 
 import type { ElectronApp } from 'electron';
 import TextElement from './TextElement';
+import DockElement from './DockElement';
 import type IonizeContainer from '../IonizeContainer';
 import type { HostContext } from '../IonizeHostConfig';
 
@@ -28,7 +29,10 @@ export default class AppElement extends BaseElement {
     this.rootContainer = rootContainer;
     this.attachedHandlers = {};
 
-    if (props.badge) this.rootContainer.app.dock.setBadge(props.badge);
+    const hasDock = props.children.some(child => child && child.type === 'dock');
+    if (!hasDock) {
+      this.rootContainer.app.dock.hide();
+    }
   }
 
   getPublicInstance(
@@ -86,21 +90,29 @@ export default class AppElement extends BaseElement {
     }
   }
 
-  commitUpdate(
-    updatePayload : Array<mixed>,
-    oldProps      : Object,
-    newProps      : Object
+  appendChild(
+    child                 : (BaseElement | TextElement)
   ): void {
-    for (let i = 0; i < updatePayload.length; i += 2) {
-      let propKey = ((updatePayload[i]: any): string);
-      let propVal = updatePayload[i+1];
-      switch (propKey) {
-        case 'badge': {
-          propVal = ((propVal: any): string);
-          this.rootContainer.app.dock.setBadge(propVal);
-          break;
-        }
-      }
+    console.log('append');
+    if (child instanceof DockElement) {
+      this.rootContainer.app.dock.show();
+    }
+  }
+
+  insertBefore(
+    child                 : (BaseElement | TextElement),
+    beforeChild           : (BaseElement | TextElement),
+  ): void {
+    if (child instanceof DockElement) {
+      this.rootContainer.app.dock.show();
+    }
+  }
+
+  removeChild(
+    child         : (BaseElement | TextElement)
+  ): void {
+    if (child instanceof DockElement) {
+      this.rootContainer.app.dock.hide();
     }
   }
 }

--- a/src/elements/DockElement.js
+++ b/src/elements/DockElement.js
@@ -1,0 +1,62 @@
+// @flow
+
+import type { ElectronDock } from 'electron';
+import type IonizeContainer from '../IonizeContainer';
+
+import BaseElement from './BaseElement';
+
+const SUPPORTED_PROPS = {
+  bouncing: true,
+  badge: true,
+};
+
+export default class DockElement extends BaseElement {
+  dock: ElectronDock
+  currentBounce: number
+
+  constructor(
+    props         : Object,
+    rootContainer : IonizeContainer,
+  ) {
+    super(props, rootContainer);
+    
+    this.dock = rootContainer.app.dock;
+
+    if (props.badge) this.dock.setBadge(props.badge);
+    if (props.bouncing) this.currentBounce = this.dock.bounce(props.bouncing);
+  }
+
+  getPublicInstance(): ElectronDock {
+    return this.dock;
+  };
+
+  getSupportedProps(): { [string]: boolean } {
+    return SUPPORTED_PROPS;
+  }
+
+  commitUpdate(
+    updatePayload : Array<mixed>,
+    oldProps      : Object,
+    newProps      : Object
+  ): void {
+    for (let i = 0; i < updatePayload.length; i += 2) {
+      let propKey = ((updatePayload[i]: any): string);
+      let propVal: any = updatePayload[i+1];
+      switch (propKey) {
+        case 'badge': {
+          this.dock.setBadge(propVal);
+          break;
+        }
+        case 'bouncing': {
+          if (typeof this.currentBounce !== 'undefined') {
+            this.dock.cancelBounce(this.currentBounce);
+            delete this.currentBounce;
+          }
+          if (propVal) {
+            this.currentBounce = this.dock.bounce(propVal)
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/elements/DockElement.js
+++ b/src/elements/DockElement.js
@@ -52,8 +52,10 @@ export default class DockElement extends BaseElement {
             this.dock.cancelBounce(this.currentBounce);
             delete this.currentBounce;
           }
-          if (propVal) {
-            this.currentBounce = this.dock.bounce(propVal)
+          if (propVal === true) {
+            this.currentBounce = this.dock.bounce();
+          } else if (propVal) {
+            this.currentBounce = this.dock.bounce(propVal);
           }
         }
       }

--- a/src/elements/index.js
+++ b/src/elements/index.js
@@ -1,5 +1,6 @@
 import BaseElement from './BaseElement';
 import AppElement from './AppElement';
+import DockElement from './DockElement';
 import WindowElement from './WindowElement';
 import GenericElement from './GenericElement';
 import TextElement from './TextElement';
@@ -15,6 +16,7 @@ import {
 export {
   BaseElement,
   AppElement,
+  DockElement,
   WindowElement,
   GenericElement,
   TextElement,
@@ -31,6 +33,9 @@ export function createElectronInstance(
   switch (type) {
     case 'app': {
       return new AppElement(props, container);
+    }
+    case 'dock': {
+      return new DockElement(props, container);
     }
     case 'window': {
       return new WindowElement(props, container);


### PR DESCRIPTION
This is mostly just me getting familiar with how all this works, it's a pretty cool project.

This adds a new prop on the `app` element for `badge`, let me know if I've done this right as I'm completely new to React Fiber 😄 

All that said I'd like to float an idea here RE the the `dock` API's, I think in the future all the `app.dock` API's should be on there on element. Kind of like this

```js
<app>
  <dock />
</app>
```

It would have to be a direct child of `app` and you can only have one mounted at a time.  Then you can map the following

* `bouncing` - String prop to indicate bouncing state, removal of prop will cancel bounce
* `icon` - The icon for the dock
* `menu` - A menu element structure 😄   Not sure if this should be a prop of dock or a child element of dock
* And then finally if the dock element is mounted or not can be mapped to the `show` and `hide` methods of `dock`.  So an absence of the element would hide the dock Etc.

For now though let's just look at this PR and if the above sounds good / needs discussion I can raise an issue for it 👍 