### PR TITLE
Add vscode config to stop flow syntax warnings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+  "javascript.validate.enable": false
+}


### PR DESCRIPTION
I (and others) use VS Code as an IDE, it has flow support through a plugin but this option needs to be enabled at a workspace level for the IDE not to fill with errors regarding the flow syntax.

Would be good to get these settings in the repo otherwise I can change the PR to add `.vscode` to the gitignore.  Whatever you want 😄 