### PR TITLE
Improve testability of BrowserWindow mocks

### DIFF
--- a/test/lib/electron.js
+++ b/test/lib/electron.js
@@ -24,6 +24,12 @@ class ElectronApp extends EventEmitter {
 export let app = new ElectronApp();
 
 class _BrowserWindow {
+  options: any;
+
+  constructor(options: any) {
+    this.options = options;
+  }
+
   show() {}
   hide() {}
   on() {}
@@ -36,20 +42,20 @@ class _BrowserWindow {
 }
 
 let i_win = 0;
-export let windows = [
-  new _BrowserWindow()
-];
+export let windows = [];
+let onNewWindowHandler: (window: _BrowserWindow) => mixed;
 
-export const BrowserWindow = () => {
-  const rval = windows[i_win];
+export const BrowserWindow = (options: any) => {
+  const newWindow = new _BrowserWindow(options);
 
-  i_win += 1;
-  if (!windows[i_win]) {
-    windows.push(new _BrowserWindow())
+  windows.push(newWindow);
+
+  if (onNewWindowHandler) {
+    onNewWindowHandler(newWindow);
   }
 
-  return rval;
-}
+  return newWindow;
+};
 
 class _Menu {
   _id: number;
@@ -144,10 +150,11 @@ export const MenuItem = (opts: Object) => {
 
 export const ElectronTestUtils = {
   getWindow(i: number) {
-    if (!windows[i]) {
-      windows[i] = new _BrowserWindow();
-    }
     return windows[i];
+  },
+
+  onNewWindow(handler: (window: _BrowserWindow) => mixed) {
+    onNewWindowHandler = handler;
   },
 
   getMenu(i: number) {
@@ -169,9 +176,7 @@ export const ElectronTestUtils = {
     i_win = 0;
     i_menu = 0;
     i_menuItem = 0;
-    windows = [
-      new _BrowserWindow()
-    ];
+    windows = [];
     menus = [
       new _Menu(0)
     ];

--- a/test/window.spec.js
+++ b/test/window.spec.js
@@ -19,8 +19,10 @@ describe('<window />', function() {
       context('during the initial mount', function() {
         context('when true', function() {
           it('the window should immediately become visible', function(done) {
-            const win = ElectronTestUtils.getWindow(0);
-            const show = sinon.stub(win, 'show');
+            let show;
+            ElectronTestUtils.onNewWindow((window) => {
+              show = sinon.stub(window, 'show');
+            });
 
             Ionize.start(
               <window show />,
@@ -34,8 +36,10 @@ describe('<window />', function() {
 
         context('when false', function() {
           it('the window should NOT become visible', function(done) {
-            const win = ElectronTestUtils.getWindow(0);
-            const show = sinon.stub(win, 'show');
+            let show;
+            ElectronTestUtils.onNewWindow((window) => {
+              show = sinon.stub(window, 'show');
+            });
 
             Ionize.start(
               <window />,
@@ -50,8 +54,10 @@ describe('<window />', function() {
         context('when an updated is committed', () => {
           context('when it transitions from FALSE to TRUE', function() {
             it('should cause the window to become visible', function(done) {
-              const win = ElectronTestUtils.getWindow(0);
-              const show = sinon.stub(win, 'show');
+              let show;
+              ElectronTestUtils.onNewWindow((window) => {
+                show = sinon.stub(window, 'show');
+              });
 
               Ionize.chain(
                 <window show={false} />, 
@@ -69,9 +75,12 @@ describe('<window />', function() {
 
           context('when it transitions from TRUE to FALSE', function() {
             it('should cause the window to become hidden', function(done) {
-              const win = ElectronTestUtils.getWindow(0);
-              const show = sinon.stub(win, 'show');
-              const hide = sinon.stub(win, 'hide');
+              let show;
+              let hide;
+              ElectronTestUtils.onNewWindow((window) => {
+                show = sinon.stub(window, 'show');
+                hide = sinon.stub(window, 'hide');
+              });
 
               Ionize.chain(
                 <window show={true} />, 
@@ -87,6 +96,84 @@ describe('<window />', function() {
               );
             })
           });
+        });
+      });
+    });
+
+    describe('acceptFirstMouse', function() {
+      context('during the initial mount', function() {
+        context('when true', function () {
+          it('the window should get acceptFirstMouse=true passed in the options', function (done) {
+            let testWindow;
+            ElectronTestUtils.onNewWindow((window) => {
+              testWindow = window;
+            });
+
+            Ionize.start(
+              <window acceptFirstMouse />,
+              () => {
+                expect(testWindow.options.acceptFirstMouse).to.be.true;
+                done();
+              }
+            );
+          });
+        });
+
+        context('when false', function () {
+          it('the window should get acceptFirstMouse=false passed in the options', function (done) {
+            let testWindow;
+            ElectronTestUtils.onNewWindow((window) => {
+              testWindow = window;
+            });
+
+            Ionize.start(
+              <window />,
+              () => {
+                expect(testWindow.options.acceptFirstMouse).to.be.false;
+                done();
+              }
+            );
+          });
+        });
+      });
+
+      context('when an updated is committed', () => {
+        context('when it transitions from FALSE to TRUE', function() {
+          it('should warn the user that this is not a valid operation', function(done) {
+            const warn = sinon.stub(console, 'warn');
+
+            Ionize.chain(
+              <window />,
+              () => {
+                expect(warn).not.to.have.been.called;
+              },
+              <window acceptFirstMouse />,
+              () => {
+                expect(warn).to.have.been.calledOnce;
+                console.warn.restore();
+                done();
+              }
+            );
+          })
+        });
+
+        context('when it transitions from TRUE to FALSE', function() {
+          it('should warn the user that this is not a valid operation', function(done) {
+            const warn = sinon.stub(console, 'warn');
+
+            Ionize.chain(
+              <window acceptFirstMouse />,
+              () => {
+                expect(warn).not.to.have.been.called;
+              },
+              <window />,
+              () => {
+                expect(warn).to.have.been.calledOnce;
+                console.warn.restore();
+                done();
+              }
+            );
+          })
         });
       });
     });


### PR DESCRIPTION
So this is my first attempt at [improving the way BrowserWindow is tested](https://github.com/mhink/react-ionize/issues/9). The only way to create a mocked BrowserWindow now is to call the constructor, which makes sure that the array of windows that’s being tracked internally always represents all the windows that were actually constructed.

I added `onNewWindow` so tests can register a handler that is called whenever a new window is constructed. This way, tests can still mock certain functions / do whatever they want with the window.

Added `acceptFirstMouse` tests for bonus points.

Let me know what you think, I could extend this to the other mocked objects as well.