### PR TITLE
Window nesting

### DIFF
--- a/examples/nested-windows.js
+++ b/examples/nested-windows.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import Ionize from 'react-ionize';
+import path from 'path';
+
+import 'index.html';
+
+class Windows extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      showFirstWindow: false,
+      showSecondWindow: false
+    }
+  }
+
+  componentDidMount() {
+    // This causes an append of a child that has children of it's own
+    setTimeout(() => this.setState(() => ({
+      showSecondWindow: true
+    })), 5000);
+
+    // This causes an insert of a child
+    setTimeout(() => this.setState(() => ({
+      showFirstWindow: true
+    })), 10000);
+
+    // This causes removal of children
+    setTimeout(() => this.setState(() => ({
+      showFirstWindow: false,
+      showSecondWindow: false
+    })), 15000);
+  }
+
+  render() {
+    return (
+      <window
+        show
+        file={path.resolve(__dirname, "index.html")}
+        defaultPosition={[50, 50]}
+      >
+        {
+          this.state.showFirstWindow && (
+            <window
+              show
+              file={path.resolve(__dirname, "index.html")}
+              defaultPosition={[100, 100]}
+            />
+          )
+        }
+        {
+          this.state.showSecondWindow && (
+            <window
+              show
+              file={path.resolve(__dirname, "index.html")}
+              defaultPosition={[150, 150]}
+            >
+              <window
+                show
+                file={path.resolve(__dirname, "index.html")}
+                defaultPosition={[200, 200]}
+              />
+            </window>
+          )
+        }
+      </window>
+    )
+  }
+}
+
+Ionize.start(
+  <Windows />
+);

--- a/src/IonizeHostConfig.js
+++ b/src/IonizeHostConfig.js
@@ -166,7 +166,7 @@ export function commitTextUpdate(
 }
 
 export type HostContext = {|
-  isMenu: boolean,
+  type: ?string
 |};
 
 const DEFAULT_HOST_CONTEXT: HostContext = ({}: any);
@@ -187,7 +187,9 @@ export function getChildHostContext(
   parentHostContext       : HostContext,
   type                    : string,
 ): HostContext {
-  return parentHostContext;
+  return {
+    type
+  };
 }
 
 // Before/after hooks to allow us to manipulate module-specific app state

--- a/src/elements/BaseElement.js
+++ b/src/elements/BaseElement.js
@@ -91,7 +91,8 @@ export default class BaseElement {
   ): void { }
 
   insertBefore(
-    child         : (BaseElement | TextElement)      
+    child         : (BaseElement | TextElement),
+    beforeChild   : (BaseElement | TextElement)
   ): void { }
 
   removeChild(

--- a/src/elements/index.js
+++ b/src/elements/index.js
@@ -33,7 +33,7 @@ export function createElectronInstance(
       return new AppElement(props, container);
     }
     case 'window': {
-      return new WindowElement(props, container);
+      return new WindowElement(props, container, context);
     }
     case 'menu': {
       return new MenuElement(props, container);


### PR DESCRIPTION
I took a stab at nesting of window elements, which turend out to be quite hard to do.

Decided not to use `setParentWindow`, because of limitations on Windows: https://github.com/electron/electron/blob/master/docs/api/browser-window.md#platform-notices

This does mean that when nested, windows need to be constructed top down, instead of bottom up, because child windows need the reference of their parent in the constructor. This is not how fiber likes to do things.

As a side effect, doing this meant that windows might not be instantiated in their own `finalizeBeforeMount ` phase, which means that adding event handlers must wait untill `commitMount`.

I don’t think I have a good enough understanding of fiber to oversee the consequences of moving the event handlers, so any ideas/feedback/comments are very welcome.